### PR TITLE
Add release branch preparation workflow and remove old commit logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           RELEASE_BRANCH="release-$(date +%Y%m%d%H%M%S)"
           git checkout -b "$RELEASE_BRANCH"
+          echo "::set-output name=RELEASE_BRANCH::$RELEASE_BRANCH"
           if [[ -n "$(git status --porcelain dist/)" ]]; then
             git add dist/
             git commit -m "Update dist folder for release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: '15 21 * * 1'
 
 jobs:
   analyze:
@@ -114,6 +112,46 @@ jobs:
       - name: Run Tests
         run: npm run test-ci
 
+  release-branch:
+    name: Prepare Release Branch
+    needs: validate
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Project
+        run: npm run build
+
+      - name: Create and Push Release Branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          RELEASE_BRANCH="release-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$RELEASE_BRANCH"
+          if [[ -n "$(git status --porcelain dist/)" ]]; then
+            git add dist/
+            git commit -m "Update dist folder for release"
+            git push origin "$RELEASE_BRANCH"
+          else
+            echo "No changes in dist folder"
+          fi
+
+      - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          head: ${{ steps.create_and_push_release_branch.outputs.RELEASE_BRANCH }}
+          title: "Release Candidate"
+          body: "Automated release candidate pull request"
+
   publish:
     # Release Publishing
     # Handles building and publishing new versions
@@ -138,28 +176,5 @@ jobs:
       - name: Build Project
         run: npm run build
 
-      - name: Commit and Push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
-          # Configure remote and fetch latest
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git fetch origin main
-          
-          # Check if there are any changes in the dist folder
-          if [[ -n "$(git status --porcelain dist/)" ]]; then
-            git add dist/
-            git commit -m "Update dist folder"
-            git push origin HEAD:main
-          else
-            echo "No changes in dist folder, skipping commit"
-          fi
-
-      - name: Tag Release
-        if: success()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=$(npm version patch)
-          git push origin HEAD:main --tags
+      - name: "Publish (Placeholder for future release logic)"
+        run: echo "Version bump and tagging now happen in a separate release workflow."


### PR DESCRIPTION
This pull request includes significant changes to the CI workflow configuration in `.github/workflows/ci.yml`. The changes focus on removing the scheduled cron job, adding a new job for preparing a release branch, and modifying the publish job to remove the commit and tag steps.