### PR TITLE
Replace GitHub Action for creating pull requests with a direct API ca…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,14 +145,19 @@ jobs:
             echo "No changes in dist folder"
           fi
 
-      - name: Open Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: main
-          head: ${{ steps.create_and_push_release_branch.outputs.RELEASE_BRANCH }}
-          title: "Release Candidate"
-          body: "Automated release candidate pull request"
+      - name: Create PR via GitHub API
+        run: |
+          PR_DATA='{
+            "title": "Release Candidate",
+            "body": "Automated release candidate pull request",
+            "head": "'"$RELEASE_BRANCH"'",
+            "base": "main"
+          }'
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls" \
+            -d "$PR_DATA"
 
   publish:
     # Release Publishing


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ci.yml` file to modify how pull requests are created during the CI process. The key change is the switch from using the `peter-evans/create-pull-request` action to using the GitHub API directly.…ll for improved flexibility